### PR TITLE
Simplified code

### DIFF
--- a/cycle-through-existing.lua
+++ b/cycle-through-existing.lua
@@ -14,70 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 --]]
 
-
-local state = {
-    selected = {V = 0, A = 0, S = 0, s = 0},
-    total = {V = 0, A = 0, S = 0}
-}
-
-local function update_selected_tracks()
-    state.selected = {
-        V = mp.get_property_native('video') or 0,
-        A = mp.get_property_native('audio') or 0,
-        S = mp.get_property_native('sub') or 0,
-        s = mp.get_property_native('secondary-sid') or 0,
-    }
-end
-
-local function update_tracks()
-    all_tracks = mp.get_property_native('track-list', {})
-    state.total = {V = 0, A = 0, S = 0}
-    for i = 1, #all_tracks do
-        local track = all_tracks[i]
-        if track.type == 'video' then
-            state.total.V = math.max(state.total.V, track.id)
-        elseif track.type == 'audio' then
-            state.total.A = math.max(state.total.A, track.id)
-        elseif track.type == 'sub' then
-            state.total.S = math.max(state.total.S, track.id)
-        end
+local function cycle(type, dir)
+    mp.command('cycle '..type..' '..dir)
+    if mp.get_property_number(type) == nil then
+        mp.command('cycle '..type..' '..dir)
     end
-    update_selected_tracks()
 end
 
-local function change(x, step) -- 'V', 'A', 'S' or 's'; -1 or +1
-    local keys = {A='audio', V='video', S='sub', s='secondary-sid'}
-    local key = keys[x]
-    update_selected_tracks()
-    local old = state.selected[x] or 0
-    local current = old + step
-    local total = state.total[string.upper(x)]
-    if current <= 0 then current = total end
-    if current > total then current = math.min(1, total) end
-    mp.command('set ' .. key .. ' ' .. current)
-end
+mp.add_key_binding(nil, 'cycle_video_up',         function() cycle('video', 'up') end)
+mp.add_key_binding(nil, 'cycle_audio_up',         function() cycle('audio', 'up') end)
+mp.add_key_binding(nil, 'cycle_sub_up',           function() cycle('sub', 'up') end)
+mp.add_key_binding(nil, 'cycle_secondary_sub_up', function() cycle('secondary-sid', 'up') end)
 
-local function _up(x)
-    return function () change(x,  1) end
-end
-
-local function _down(x)
-    return function () change(x, -1) end
-end
-
-mp.register_event('start-file', update_tracks)
-mp.register_event('file-loaded', update_tracks)
-mp.observe_property('tracks-changed', 'native', update_tracks)
-
-mp.add_key_binding(nil, 'cycle_video_up',         _up('V'))
-mp.add_key_binding(nil, 'cycle_audio_up',         _up('A'))
-mp.add_key_binding(nil, 'cycle_sub_up',           _up('S'))
-mp.add_key_binding(nil, 'cycle_secondary_sub_up', _up('s'))
-
-mp.add_key_binding(nil, 'cycle_video_down',         _down('V'))
-mp.add_key_binding(nil, 'cycle_audio_down',         _down('A'))
-mp.add_key_binding(nil, 'cycle_sub_down',           _down('S'))
-mp.add_key_binding(nil, 'cycle_secondary_sub_down', _down('s'))
+mp.add_key_binding(nil, 'cycle_video_down',         function() cycle('video', 'down') end)
+mp.add_key_binding(nil, 'cycle_audio_down',         function() cycle('audio', 'down') end)
+mp.add_key_binding(nil, 'cycle_sub_down',           function() cycle('sub', 'down') end)
+mp.add_key_binding(nil, 'cycle_secondary_sub_down', function() cycle('secondary-sid', 'down') end)
 
 --[[
 EXAMPLE (input.conf):


### PR DESCRIPTION
Hi, isn't your code unnecessarily complex? What do you think about this? It also eliminates the bug in your script where the primary and secondary subtitle track can't get "past" each other, e.g. when there are 4 subtitle tracks and the primary subtitle track is 2, you can only select track 1 as the secondary subtitle when cycling up, and you have to cycle backwards to get to the other side of 2.

Edit: forgot to add, the property `tracks-changed` used in this line of your code doesn't seem to exist:
```lua
mp.observe_property('tracks-changed', 'native', update_tracks)
``` 
The (current) mpv manual doesn't mention it at all. Was it used in an old version of mpv?